### PR TITLE
Enforces karma config tmp extension

### DIFF
--- a/lib/tasks/karma.rake
+++ b/lib/tasks/karma.rake
@@ -10,7 +10,8 @@ namespace :karma  do
   private
 
   def with_tmp_config(command, args = nil)
-    Tempfile.open('karma_unit.js', Rails.root.join('tmp')) do |f|
+    # Change to [.., '.coffee'] for any CS config files
+    Tempfile.open(['karma_unit', '.js'], Rails.root.join('tmp')) do |f|
       f.write unit_js(application_spec_files)
       f.flush
 


### PR DESCRIPTION
If people want to use coffeescript karma configuration, then this
tempfile would be generated with a .coffee#{hash} extension, preventing
karma from correctly detecting the coffeescript file extension.

This commit specifies the tempfile extension and preserves .js/.coffee.
